### PR TITLE
Fix check if wait_cmd was defined

### DIFF
--- a/resources/docker_container/1.0.0/actions/run.yaml
+++ b/resources/docker_container/1.0.0/actions/run.yaml
@@ -37,7 +37,7 @@
        {% endif %}
 
     - name: Waiting for app in container
-      when: {{wait_cmd}}
+      when: '"{{wait_cmd|e}}" != "None"'
       shell: docker exec -t {{ resource_name }} {{wait_cmd}}
       register: result
       until: result.rc == 0


### PR DESCRIPTION
In when statement ansible expects bool value. If wait command was
not defined None is returned.
