### PR TITLE
Change delay to 1s

### DIFF
--- a/resources/mariadb_service/1.0.0/actions/run.yaml
+++ b/resources/mariadb_service/1.0.0/actions/run.yaml
@@ -17,6 +17,6 @@
     - shell: docker exec -t {{ resource_name }} mysql -p{{ root_password }} -uroot -e "SELECT 1"
       register: result
       until: result.rc == 0
-      retries: 30
-      delay: 0.5
+      retries: 15
+      delay: 1
 


### PR DESCRIPTION
Something changed in Ansible 2.0 and values lower than 1 works in "strange" way.
Instead of waiting half second it wait aobut 0.1 second.
